### PR TITLE
Search Improvements 

### DIFF
--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -46,9 +46,9 @@ export default function Search({ onSubmit, initialSearchValue: initialSearch = "
       <ul>
         <li>A specific section: CS 1337.501</li>
         <li>A whole course: CS 1337</li>
-        <li>A professor&apos;s name (last name or full): Jason Smith</li>
-        <li>A specific semester: CS 1337 fall 2017</li>
-        <li>Everything together: CS 1337.1 fall 2017 jason smith</li>
+        <li>A professor&apos;s name: Jason Smith</li>
+        <li>A specific semester: CS 1337 Fall 2021</li>
+        <li>Everything together: CS 1337.001 Fall 2021 Jason Smith</li>
       </ul>
     </Popover>
   );
@@ -77,7 +77,11 @@ export default function Search({ onSubmit, initialSearchValue: initialSearch = "
 
   return (
     <AntForm>
-      <StyledAutoComplete options={options}>
+      <StyledAutoComplete
+        options={options}
+        // TODO: find a better value than unknown
+        onSelect={(value: unknown) => onSubmit({ search: value as string })}
+      >
         <StyledSearch
           onSearch={(search) => onSubmit({ search })}
           onChange={onChange}

--- a/client/src/components/SearchResults.tsx
+++ b/client/src/components/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { Col, Row } from "antd";
 import type { NextRouter } from "next/router";
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useQuery } from "react-query";
 import { animateScroll as scroll } from "react-scroll";
 import styled from "styled-components";
@@ -90,6 +90,13 @@ export default function Results({ search, sectionId, router }: ResultsProps) {
     { enabled: !!section }
   );
 
+  useEffect(() => {
+    // Automatically select section if there is only one choice
+    if (sections && sections.length == 1) {
+      handleClick(sections[0]!.id);
+    }
+  }, [sections]);
+
   function handleSubmit({ search }: SearchQuery) {
     (async function () {
       await router.push({
@@ -107,7 +114,7 @@ export default function Results({ search, sectionId, router }: ResultsProps) {
       });
     })();
 
-    const scrollDistance = window.pageYOffset + scrollRef.current!.getBoundingClientRect().top;
+    const scrollDistance = window.scrollY + scrollRef.current!.getBoundingClientRect().top;
 
     scroll.scrollTo(scrollDistance);
   }
@@ -120,7 +127,7 @@ export default function Results({ search, sectionId, router }: ResultsProps) {
       });
     })();
 
-    const scrollDistance = window.pageYOffset + scrollRef.current!.getBoundingClientRect().top;
+    const scrollDistance = window.scrollY + scrollRef.current!.getBoundingClientRect().top;
 
     scroll.scrollTo(scrollDistance);
   }

--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -71,8 +71,18 @@ FROM grades
          INNER JOIN strings section ON section.id = grades.sectionId
          INNER JOIN strings instructor1 ON instructor1.id = grades.instructor1Id;
 
-CREATE VIEW grades_strings(id,string,subject,courseSection,semester,instructor1) AS
+-- FIXME: grades_strings is no longer an appropriate name, since autocomplete now use autocomplete_strings
+CREATE VIEW grades_strings(id,subject,courseSection,semester,instructor1) AS
 SELECT gradesId,
+       subject,
+       catalogNumber || '.' || section,
+       semester,
+       instructor1
+FROM grades_populated;
+
+CREATE VIEW autocomplete_strings(priority,string,subject,courseSection,semester,instructor1) AS
+-- CS 1337.001 Fall 2020 Firstname Lastname
+SELECT 4,
        subject       || ' ' ||
        catalogNumber || '.' ||
        section       || ' ' ||
@@ -82,4 +92,48 @@ SELECT gradesId,
        catalogNumber || '.' || section,
        semester,
        instructor1
+from grades_populated
+UNION
+-- CS 1337 Fall 2020 Firstname Lastname
+SELECT 3,
+       subject       || ' ' ||
+       catalogNumber || ' ' ||
+       semester      || ' ' ||
+       instructor1,
+       subject,
+       catalogNumber,
+       semester,
+       instructor1
+FROM grades_populated
+UNION
+-- CS 1337 Firstname Lastname
+SELECT 2,
+       subject || ' ' ||
+       catalogNumber || ' ' ||
+       instructor1,
+       subject,
+       catalogNumber,
+       '',
+       instructor1
+from grades_populated
+UNION
+-- CS 1337 Fall 2020
+SELECT 1,
+       subject       || ' ' ||
+       catalogNumber || ' ' ||
+       semester,
+       subject,
+       catalogNumber,
+       semester,
+       ''
+FROM grades_populated
+UNION
+-- CS 1337
+SELECT 0,
+       subject || ' ' ||
+       catalogNumber,
+       subject,
+       catalogNumber,
+       '',
+       ''
 FROM grades_populated;

--- a/db/src/search/GradesDatabase.ts
+++ b/db/src/search/GradesDatabase.ts
@@ -13,6 +13,10 @@ export class GradesDatabase {
     this.db.close();
   }
 
+  /**
+   * Retrieve all sections for a full search query
+   * @param search
+   */
   getSectionsBySearch(search: string): Grades[] {
     const grades: Grades[] = [];
 
@@ -51,13 +55,17 @@ export class GradesDatabase {
     return grades;
   }
 
+  /**
+   * Provide options for autocomplete (partial) queries
+   * @param partialQuery
+   */
   getSectionStrings(partialQuery: string): string[] {
     if (partialQuery === "") return [];
 
     const strings: string[] = [];
 
     const stmt = this.db.prepare(
-      `SELECT string FROM grades_strings WHERE ${createWhereString(partialQuery)}`
+      `SELECT string FROM autocomplete_strings WHERE ${createWhereString(partialQuery)} ORDER BY priority`
     );
 
     while (stmt.step()) {


### PR DESCRIPTION
Autocomplete/search improvements
- Run search upon selecting autocomplete choice
- Automatically display graph if there is only one section.
  - Makes sense because if user selects a specific section in the autocomplete dropdown, they'll want to display that single search result immediately
- Show broad autocomplete strings, such as "CS 1337," instead of only autocompleting for single sections
- Order the autocomplete strings by "broadness," defined by a priority number in the new autocomplete_strings view

Other minor changes:
- Update the "What can you search" hint
- Use `window.scrollY` bc `pageYOffset` is deprecated. 