### PR TITLE
Fix searches with no space between components

### DIFF
--- a/db/src/search/utils.ts
+++ b/db/src/search/utils.ts
@@ -127,15 +127,18 @@ export function createWhereString(search: string): string {
   semester: '20', '18', '2018', 'Fall' should all match 'Fall 2018'
   instructor1: 'John', 'Cole' should match 'John Cole'. 'Ali' should match 'Alice' but not 'Salisbury'
    */
-  return search
-    .split(" ")
-    .map((s) => `(
+  // Split into tokens: first on whitespace, then on number/word boundaries (cs1337 => cs 1337)
+  const tokens = search.split(/\s/).flatMap((x) => Array.from(x.matchAll(/\d+|\D+/g), (m) => m[0]));
+  return tokens
+    .map(
+      (s) => `(
       subject LIKE '${s}%' OR
       courseSection LIKE '${s}%' OR
       semester LIKE '%${s}%' OR
       instructor1 LIKE '${s}%' OR
       instructor1 LIKE '% ${s}%'
-    )`)
+    )`
+    )
     .join(" AND ");
 }
 


### PR DESCRIPTION
People are used to searching for phrases like cs2336, which our current split-by-space method doesn't process correctly. This change further splits each token by number/word boundaries.

The effect: "cs2336" matches "CS 2336", and "f21" matches "Fall 2021"  

![Screen Shot 2022-04-14 at 11 33 56 AM](https://user-images.githubusercontent.com/36653830/163433743-8ac57486-2417-4165-95cf-7775b52c62f0.png)
