### PR TITLE
Fix autocomplete not matching dot in search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 out/
 *.sqlite3
 tsconfig.tsbuildinfo
+.idea
+.DS_Store

--- a/db/src/search/utils.ts
+++ b/db/src/search/utils.ts
@@ -128,7 +128,9 @@ export function createWhereString(search: string): string {
   instructor1: 'John', 'Cole' should match 'John Cole'. 'Ali' should match 'Alice' but not 'Salisbury'
    */
   // Split into tokens: first on whitespace, then on number/word boundaries (cs1337 => cs 1337)
-  const tokens = search.split(/\s/).flatMap((x) => Array.from(x.matchAll(/\d+|\D+/g), (m) => m[0]));
+  const tokens = search
+    .split(/\s/)
+    .flatMap((x) => Array.from(x.matchAll(/[\d.]+|\D+/g), (m) => m[0]));
   return tokens
     .map(
       (s) => `(


### PR DESCRIPTION
oops
my regex was one character off, so it would split `CS 1337.001` into `['CS', '1337', '001']` The `001` does not match as a prefix of courseSection, so `CS 1337.001` would give no results. 

Also added entries to gitignore for mac and jetbrains.