### PR TITLE
Fix readme github pages badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UTD Grades
 
-![Deploy to GitHub Pages](https://github.com/darichey/utd-grades/actions/workflows/deploy.yml/badge.svg) <!-- TODO: change repo URL -->
+![Deploy to GitHub Pages](https://github.com/acmutd/utd-grades/actions/workflows/deploy.yml/badge.svg)
 
 UTD Grades is an application for viewing grade distributions at UT Dallas.
 


### PR DESCRIPTION
The badge in the readme still points to my (now non-existent) repo. Update it to this repo.