### PR TITLE
Build and test in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "17"
+          cache: "npm"
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test


### PR DESCRIPTION
Add a github workflow to run `npm run build` and `npm run test` on pushes to master and on PRs. The build exercises building the db while the tests exercise some searching functionality. This should prevent mistakes like me missing the malformed header in #55, because the build would have failed on the PR.

This PR depends on #56 and #59, review and merge those first :)