### PR TITLE
disabling github action deployment script due to vercel integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
-name: Deploy to GitHub Pages
+name: Deploy to GitHub Pages (DISABLED - Using Vercel)
 
 on:
-  push:
-    branches:
-      - master
+  # Disabled - now using Vercel for deployment
+  # push:
+  #   branches:
+  #     - master
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Currently the github actions script is still deploying but the cloudflare records for the deployment have been overwritten by vercel. To reduce confusion on which one is actually doing the deployment, I'm just commenting out the trigger so we still have the code as a fallback